### PR TITLE
Ios audio

### DIFF
--- a/build/ios.mk
+++ b/build/ios.mk
@@ -36,6 +36,13 @@ IOS_GRAPHICS = \
 	$(IOS_GRAPHICS_DIR)/Assets.car \
 	$(IOS_GRAPHICS_DIR)/LaunchScreen.storyboardc
 
+# Copy WAV files directly (no conversion needed)
+WAV_SOUNDS = $(wildcard Data/sound/*.wav)
+IOS_SOUNDS = $(patsubst Data/sound/%.wav,$(DATA)/sound/%.wav,$(WAV_SOUNDS))
+$(DATA)/sound/%.wav: Data/sound/%.wav | $(DATA)/sound/dirstamp
+	@$(NQ)echo "  CP      $@"
+	$(Q)cp $< $@
+
 $(IOS_GRAPHICS_DIR)/Assets.xcassets: $(topdir)/Data/iOS/Assets.xcassets $(IOS_ICON_SVG) | $(IOS_GRAPHICS_DIR)/dirstamp
 	$(Q)cp -r $< $@
 	$(Q)rsvg-convert $(IOS_ICON_SVG) -w 1024 -h 1024 -a -b white -o $@/AppIcon.appiconset/Icon-1024.png

--- a/build/resource.mk
+++ b/build/resource.mk
@@ -152,22 +152,11 @@ $(PNG_LAUNCH_ALL): %.png: %.bmp
 
 ####### sounds
 
-WAV_SOUNDS = $(wildcard Data/sound/*.wav)
-
-ifeq ($(TARGET_IS_IOS),y)
-# iOS: Copy WAV files directly (no conversion needed)
-IOS_SOUNDS = $(patsubst Data/sound/%.wav,$(DATA)/sound/%.wav,$(WAV_SOUNDS))
-
-$(IOS_SOUNDS): $(DATA)/sound/%.wav: Data/sound/%.wav | $(DATA)/sound/dirstamp
-	@$(NQ)echo "  CP      $@"
-	$(Q)cp $< $@
-
-RESOURCE_FILES += $(IOS_SOUNDS)
-
-else
 ifneq ($(TARGET),ANDROID)
+ifneq ($(TARGET),IOS)
 ifneq ($(HAVE_WIN32),y)
 
+WAV_SOUNDS = $(wildcard Data/sound/*.wav)
 RAW_SOUNDS = $(patsubst Data/sound/%.wav,$(DATA)/sound/%.raw,$(WAV_SOUNDS))
 
 $(RAW_SOUNDS): $(DATA)/sound/%.raw: Data/sound/%.wav | $(DATA)/sound/dirstamp

--- a/build/resource.mk
+++ b/build/resource.mk
@@ -191,6 +191,7 @@ $(TARGET_OUTPUT_DIR)/include/MakeResource.hpp: $(TARGET_OUTPUT_DIR)/resources.tx
 	$(Q)mv $@.$(RANDOM_NUMBER).tmp $@
 
 ifeq ($(TARGET_IS_ANDROID),n)
+ifneq ($(TARGET),IOS)
 
 ifeq ($(USE_WIN32_RESOURCES),y)
 RESOURCE_FILES += $(BMP_BITMAPS)
@@ -217,9 +218,10 @@ $(patsubst $(DATA)/graphics/%.bmp,$(DATA)/graphics2/%.png,$(filter $(DATA)/graph
 RESOURCE_FILES := $(patsubst $(DATA)/graphics/%.bmp,$(DATA)/graphics2/%.png,$(RESOURCE_FILES))
 RESOURCE_FILES := $(patsubst $(DATA)/icons/%.bmp,$(DATA)/icons2/%.png,$(RESOURCE_FILES))
 RESOURCE_FILES := $(patsubst %.bmp,%.png,$(RESOURCE_FILES))
-endif
+endif #!USE_WIN32_RESOURCES
 
-endif
+endif #TARGET!=IOS
+endif #!TARGET_IS_ANDROID
 
 ifeq ($(TARGET_IS_ANDROID),n)
 

--- a/src/Apple/Services.cpp
+++ b/src/Apple/Services.cpp
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright The XCSoar Project
 
-#include "Services.hpp"
-#include "LogFile.hpp"
+#ifdef __APPLE__
 
 #include <TargetConditionals.h>
-
-#if TARGET_OS_IPHONE
+#include "LogFile.hpp"
+#include "Services.hpp"
 #import <AVFoundation/AVFoundation.h>
-#endif
 
 // Initialize apple services - this will be called from the main XCSoar startup
 void
@@ -41,3 +39,5 @@ DeinitializeAppleServices()
   }
 #endif
 }
+
+#endif

--- a/src/Apple/SoundUtil.cpp
+++ b/src/Apple/SoundUtil.cpp
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright The XCSoar Project
 
+// Implementation of SoundUtil using the AVFoundation framework 
+// Currently for iOS only, not macOS (AVAudioSession is iOS only)
+
 #include "SoundUtil.hpp"
 #include "LogFile.hpp"
 
@@ -20,7 +23,7 @@ SoundUtil::Play(const TCHAR *resource_name)
 {
 #if TARGET_OS_IPHONE
   // Map resource names to actual file names
-  // ToDo: Avoid duplication of static information with android/src/SoundUtil.java ?
+  // ToDo: Avoid duplication of static mapping information with android/src/SoundUtil.java ?
   const char *filename = nullptr;
   if (strcmp(resource_name, "IDR_FAIL") == 0) {
     filename = "fail";


### PR DESCRIPTION
Thinking about it again, the WAV files should not be copied in `resource.mk` but in `ios.mk`.  This is since/so they don't end up in the compiled resources...

89fcfc546925477a1c90f62a6b07b4ef0bb957e4 is additional cleanup, can also hand this in as a separate PR