### PR TITLE
QuickGuide: Make compile for WIN64

### DIFF
--- a/build/resource.mk
+++ b/build/resource.mk
@@ -223,14 +223,26 @@ endif
 ####### add gesture icons from docs
 
 GESTURES = d dl dr du l ldr ldrdl r rd rl u ud uldr urd urdl
-GESTURES_DST = $(addprefix $(DATA)/graphics2/gesture_,$(addsuffix .png,$(GESTURES)))
+GESTURES_DST = $(addprefix $(DATA)/graphics2/gesture_, \
+	$(addsuffix .png,$(GESTURES)))
+GESTURES_PNG_WIN = $(addprefix $(DATA)/graphics/gesture_, \
+	$(addsuffix .png,$(GESTURES)))
+GESTURES_BMP_WIN = $(GESTURES_PNG_WIN:.png=.bmp)
 
 $(DATA)/graphics2/dirstamp:
 	@$(NQ)echo "  MKDIR   $(DATA)/graphics2/"
 	$(Q)mkdir -p $(DATA)/graphics2
 	@touch $@
 
-$(eval $(call rsvg-convert,$(GESTURES_DST),$(DATA)/graphics2/gesture_%.png,doc/manual/figures/gesture_%.svg,--width=82 --height=82))
+$(eval $(call rsvg-convert,$(GESTURES_DST), \
+	$(DATA)/graphics2/gesture_%.png, \
+	doc/manual/figures/gesture_%.svg, \
+	--width=82 --height=82))
+$(eval $(call rsvg-convert,$(GESTURES_PNG_WIN), \
+	$(DATA)/graphics/gesture_%.png, \
+	doc/manual/figures/gesture_%.svg, \
+	--width=82 --height=82))
+$(eval $(call convert-to-bmp-white,$(GESTURES_BMP_WIN),%.bmp,%.png))
 
 RESOURCE_FILES += $(GESTURES_DST)
 RESOURCE_FILES += $(BMP_ICONS_ALL)
@@ -253,6 +265,10 @@ RESOURCE_FILES := $(patsubst $(DATA)/graphics/%.bmp,$(DATA)/graphics2/%.png,$(RE
 RESOURCE_FILES := $(patsubst $(DATA)/icons/%.bmp,$(DATA)/icons2/%.png,$(RESOURCE_FILES))
 RESOURCE_FILES := $(patsubst %.bmp,%.png,$(RESOURCE_FILES))
 endif #!USE_WIN32_RESOURCES
+
+ifeq ($(USE_WIN32_RESOURCES),y)
+RESOURCE_FILES += $(GESTURES_BMP_WIN)
+endif #USE_WIN32_RESOURCES
 
 endif #TARGET!=IOS
 endif #!TARGET_IS_ANDROID

--- a/src/Dialogs/QuickGuide/ConfigurationWidget.cpp
+++ b/src/Dialogs/QuickGuide/ConfigurationWidget.cpp
@@ -11,7 +11,7 @@
 #include "system/Path.hpp"
 #include "util/StringCompare.hxx"
 #include "util/OpenLink.hpp"
-#include "util/ConvertString.hpp"
+#include "util/StaticString.hxx"
 #include "Look/DialogLook.hpp"
 #include "UIGlobals.hpp"
 #include "Dialogs/Dialogs.h"
@@ -31,7 +31,6 @@
 #include "Waypoint/Patterns.hpp"
 
 #include <winuser.h>
-#include <fmt/format.h>
 
 PixelSize ConfigurationWidget::GetMinimumSize() const noexcept {
   return { Layout::FastScale(200), Layout::FastScale(200) };
@@ -41,7 +40,10 @@ PixelSize ConfigurationWidget::GetMaximumSize() const noexcept {
   return { Layout::FastScale(300), Layout::FastScale(800) };
 }
 
-void ConfigurationWidget::Initialise(ContainerWindow &parent, const PixelRect &rc) noexcept {
+void
+ConfigurationWidget::Initialise(ContainerWindow &parent,
+                                const PixelRect &rc) noexcept
+{
   WindowStyle style;
   style.Hide();
   auto w = std::make_unique<ConfigurationWindow>();
@@ -61,8 +63,8 @@ ConfigurationWindow::OnPaint(Canvas &canvas) noexcept
   int x_text = x + Layout::FastScale(20);
   int y = rc.top + margin;
   int icon_offset = Layout::FastScale(1);
-  constexpr const char* undone = "[ ]";
-  constexpr const char* done   = "[X]";
+  constexpr const TCHAR *undone = _T("[ ]");
+  constexpr const TCHAR *done = _T("[X]");
 
   const DialogLook &look = UIGlobals::GetDialogLook();
 
@@ -81,151 +83,191 @@ ConfigurationWindow::OnPaint(Canvas &canvas) noexcept
   canvas.DrawText({x, y + icon_offset}, c1 == nullptr ? undone : done);
   canvas.Select(fontDefault);
   const TCHAR *t1 = _("Download the map for your region");
-  PixelRect t1_rc{x_text, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
+  PixelRect t1_rc{x_text, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
   unsigned t1_height = canvas.DrawFormattedText(t1_rc, t1, DT_LEFT);
   y += int(t1_height) + margin / 2;
   canvas.Select(fontMono);
   const TCHAR *l1 = _("Config → System → Site Files");
-  PixelRect l1_rc{x_text, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
+  PixelRect l1_rc{x_text, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
   unsigned l1_height = DrawLink(canvas, LinkAction::SITE_FILES_1, l1_rc, l1);
   y += int(l1_height) + margin;
   
   // Waypoints
   canvas.Select(fontMono);
-  const auto c2 = Profile::GetMultiplePaths(ProfileKeys::WaypointFileList, WAYPOINT_FILE_PATTERNS);
+  const auto c2 =
+    Profile::GetMultiplePaths(ProfileKeys::WaypointFileList,
+                              WAYPOINT_FILE_PATTERNS);
   canvas.DrawText({x, y + icon_offset}, c2.size() == 0 ? undone : done);
   canvas.Select(fontDefault);
   const TCHAR *t2 = _("Download waypoints for your region");
-  PixelRect t2_rc{x_text, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
+  PixelRect t2_rc{x_text, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
   unsigned t2_height = canvas.DrawFormattedText(t2_rc, t2, DT_LEFT);
   y += int(t2_height) + margin / 2;
   canvas.Select(fontMono);
   const TCHAR *l2 = _("Config → System → Site Files");
-  PixelRect l2_rc{x_text, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
+  PixelRect l2_rc{x_text, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
   unsigned l2_height = DrawLink(canvas, LinkAction::SITE_FILES_2, l2_rc, l2);
   y += int(l2_height) + margin;
 
   // Airspace
   canvas.Select(fontMono);
-  const auto c3 = Profile::GetMultiplePaths(ProfileKeys::AirspaceFileList, AIRSPACE_FILE_PATTERNS);
+  const auto c3 =
+    Profile::GetMultiplePaths(ProfileKeys::AirspaceFileList,
+                              AIRSPACE_FILE_PATTERNS);
   canvas.DrawText({x, y + icon_offset}, c3.size() == 0 ? undone : done);
   canvas.Select(fontDefault);
   const TCHAR *t3 = _("Download airspaces for your region");
-  PixelRect t3_rc{x_text, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
+  PixelRect t3_rc{x_text, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
   unsigned t3_height = canvas.DrawFormattedText(t3_rc, t3, DT_LEFT);
   y += int(t3_height) + margin / 2;
   canvas.Select(fontMono);
   const TCHAR *l3 = _("Config → System → Site Files");
-  PixelRect l3_rc{x_text, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
+  PixelRect l3_rc{x_text, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
   unsigned l3_height = DrawLink(canvas, LinkAction::SITE_FILES_3, l3_rc, l3);
   y += int(l3_height) + margin;
 
   // Aircraft polar
   canvas.Select(fontMono);
   const char *c4 = Profile::Get(ProfileKeys::Polar); // TODO does not work
-  canvas.DrawText({x, y + icon_offset}, (c4 == nullptr || StringIsEmpty(c4)) ? undone : done);
+  canvas.DrawText({x, y + icon_offset},
+                  (c4 == nullptr || StringIsEmpty(c4)) ? undone : done);
   canvas.Select(fontDefault);
-  const TCHAR *t4 = _("Add your aircraft and, most importantly, select the corresponding polar curve and activate the aircraft, so that the flight computer can calculate everything correctly.");
-  PixelRect t4_rc{x_text, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
+  const TCHAR *t4 = _("Add your aircraft and, most importantly, select "
+                      "the corresponding polar curve and activate the "
+                      "aircraft, so that the flight computer can calculate "
+                      "everything correctly.");
+  PixelRect t4_rc{x_text, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
   unsigned t4_height = canvas.DrawFormattedText(t4_rc, t4, DT_LEFT);
   y += int(t4_height) + margin / 2;
   canvas.Select(fontMono);
   const TCHAR *l4 = _("Config → Setup Plane → New → Polar → List");
-  PixelRect l4_rc{x_text, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
+  PixelRect l4_rc{x_text, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
   unsigned l4_height = DrawLink(canvas, LinkAction::PLANE_POLAR, l4_rc, l4);
   y += int(l4_height) + margin;
 
   // Pilot name
   canvas.Select(fontMono);
   const char *c5 = Profile::Get(ProfileKeys::PilotName);
-  canvas.DrawText({x, y + icon_offset}, (c5 == nullptr || StringIsEmpty(c5)) ? undone : done);
+  canvas.DrawText({x, y + icon_offset},
+                  (c5 == nullptr || StringIsEmpty(c5)) ? undone : done);
   canvas.Select(fontDefault);
   const TCHAR *t5 = _("Set your name.");
-  PixelRect t5_rc{x_text, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
+  PixelRect t5_rc{x_text, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
   unsigned t5_height = canvas.DrawFormattedText(t5_rc, t5, DT_LEFT);
   y += int(t5_height) + margin / 2;
   canvas.Select(fontMono);
   const TCHAR *l5 = _("Config → System → Setup → Logger");
-  PixelRect l5_rc{x_text, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
+  PixelRect l5_rc{x_text, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
   unsigned l5_height = DrawLink(canvas, LinkAction::SETUP_LOGGER_1, l5_rc, l5);
   y += int(l5_height) + margin;
 
   // Pilot weight
   canvas.Select(fontMono);
   const char *c6 = Profile::Get(ProfileKeys::CrewWeightTemplate);
-  canvas.DrawText({x, y + icon_offset}, (c6 == nullptr || StringIsEmpty(c6) || (intptr_t)c6 <= 0) ? undone : done);
+  canvas.DrawText({x, y + icon_offset},
+                  (c6 == nullptr || StringIsEmpty(c6) ||
+                   (intptr_t)c6 <= 0) ? undone : done);
   canvas.Select(fontDefault);
   const TCHAR *t6 = _("Set your default weight.");
-  PixelRect t6_rc{x_text, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
+  PixelRect t6_rc{x_text, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
   unsigned t6_height = canvas.DrawFormattedText(t6_rc, t6, DT_LEFT);
   y += int(t6_height) + margin / 2;
   canvas.Select(fontMono);
   const TCHAR *l6 = _("Config → System → Setup → Logger");
-  PixelRect l6_rc{x_text, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
+  PixelRect l6_rc{x_text, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
   unsigned l6_height = DrawLink(canvas, LinkAction::SETUP_LOGGER_2, l6_rc, l6);
   y += int(l6_height) + margin;
 
   // Timezone (UTC offset)
   canvas.Select(fontMono);
   int utc_offset;
-  canvas.DrawText({x, y + icon_offset}, (!Profile::Get(ProfileKeys::UTCOffsetSigned, utc_offset) ? undone : done));
+  canvas.DrawText({x, y + icon_offset},
+                  (!Profile::Get(ProfileKeys::UTCOffsetSigned, utc_offset)
+                   ? undone : done));
   canvas.Select(fontDefault);
   const TCHAR *t7 = _("Set your timezone.");
-  PixelRect t7_rc{x_text, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
+  PixelRect t7_rc{x_text, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
   unsigned t7_height = canvas.DrawFormattedText(t7_rc, t7, DT_LEFT);
   y += int(t7_height) + margin / 2;
   canvas.Select(fontMono);
   const TCHAR *l7 = _("Config → System → Setup → Time");
-  PixelRect l7_rc{x_text, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
+  PixelRect l7_rc{x_text, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
   unsigned l7_height = DrawLink(canvas, LinkAction::SETUP_TIME, l7_rc, l7);
   y += int(l7_height) + margin;
 
   // Home waypoint
   canvas.Select(fontMono);
   int home_waypoint;
-  canvas.DrawText({x, y + icon_offset}, (!Profile::Get(ProfileKeys::HomeWaypoint, home_waypoint) ? undone : done)); // TODO HomeWaypoint vs HomeLocation
+  canvas.DrawText({x, y + icon_offset},
+                  (!Profile::Get(ProfileKeys::HomeWaypoint, home_waypoint)
+                   ? undone : done)); // TODO HomeWaypoint vs HomeLocation
   canvas.Select(fontDefault);
   const TCHAR *t8 = _("Set home airfield.");
-  PixelRect t8_rc{x_text, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
+  PixelRect t8_rc{x_text, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
   unsigned t8_height = canvas.DrawFormattedText(t8_rc, t8, DT_LEFT);
   y += int(t8_height) + margin / 2;
   canvas.Select(fontMono);
-  const TCHAR *l8 = _("Tap waypoint on map → select waypoint → Details → next page → Set as New Home");
-  PixelRect l8_rc{x_text, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
+  const TCHAR *l8 = _("Tap waypoint on map → select waypoint → Details "
+                      "→ next page → Set as New Home");
+  PixelRect l8_rc{x_text, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
   unsigned l8_height = canvas.DrawFormattedText(l8_rc, l8, DT_LEFT);
   y += int(l8_height) + margin;
 
   // InfoBoxes
   canvas.Select(fontDefault);
   const TCHAR *t9 = _("Configure the pages and InfoBoxes as you prefer.");
-  PixelRect t9_rc{x_text, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
+  PixelRect t9_rc{x_text, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
   unsigned t9_height = canvas.DrawFormattedText(t9_rc, t9, DT_LEFT);
   y += int(t9_height) + margin / 2;
   canvas.Select(fontMono);
   const TCHAR *l9 = _("Config → System → Look → InfoBox Sets");
-  PixelRect l9_rc{x_text, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
-  unsigned l9_height = DrawLink(canvas, LinkAction::LOOK_INFO_BOX_SETS, l9_rc, l9);
+  PixelRect l9_rc{x_text, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
+  unsigned l9_height = DrawLink(canvas, LinkAction::LOOK_INFO_BOX_SETS,
+                                l9_rc, l9);
   y += int(l9_height) + margin / 2;
   const TCHAR *l9b = _("Config → System → Look → Pages");
-  PixelRect l9b_rc{x_text, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
+  PixelRect l9b_rc{x_text, y, int(canvas.GetWidth()) - margin,
+                   int(canvas.GetHeight())};
   unsigned l9b_height = DrawLink(canvas, LinkAction::LOOK_PAGES, l9b_rc, l9b);
   y += int(l9b_height) + margin / 2;
   canvas.SetTextColor(COLOR_BLUE);
-  const TCHAR *l9c = _("https://youtube.com/user/M24Tom/playlists"); // https://youtube.com/playlist?list=PLb36zVafnfctzNG7yJoNXc2x8HnX5J9j7
-  PixelRect l9c_rc{x_text, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
-  unsigned l9c_height = DrawLink(canvas, LinkAction::YOUTUBE_TUTORIAL, l9c_rc, l9c);
+  const TCHAR *l9c = _("https://youtube.com/user/M24Tom/playlists");
+  PixelRect l9c_rc{x_text, y, int(canvas.GetWidth()) - margin,
+                   int(canvas.GetHeight())};
+  unsigned l9c_height =
+    DrawLink(canvas, LinkAction::YOUTUBE_TUTORIAL, l9c_rc, l9c);
   canvas.SetTextColor(COLOR_BLACK);
   y += int(l9c_height) + margin;
   
   // NMEA devices
   canvas.Select(fontDefault);
   const TCHAR *t10 = _("Configure NMEA devices via Bluetooth or USB-Serial.");
-  PixelRect t10_rc{x_text, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
+  PixelRect t10_rc{x_text, y, int(canvas.GetWidth()) - margin,
+                   int(canvas.GetHeight())};
   unsigned t10_height = canvas.DrawFormattedText(t10_rc, t10, DT_LEFT);
   y += int(t10_height) + margin / 2;
   canvas.Select(fontMono);
   const TCHAR *l10 = _("Config → Devices");
-  PixelRect l10_rc{x_text, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
+  PixelRect l10_rc{x_text, y, int(canvas.GetWidth()) - margin,
+                   int(canvas.GetHeight())};
   unsigned l10_height = DrawLink(canvas, LinkAction::DEVICES, l10_rc, l10);
   y += int(l10_height) + margin;
 
@@ -233,24 +275,40 @@ ConfigurationWindow::OnPaint(Canvas &canvas) noexcept
 
   // Replay
   canvas.Select(fontDefault);
-  std::string t97s = fmt::format("{} {} {}",
-    _("The easiest way to get familiar with XCSoar is to load an existing flight and use the replay feature to explore its functions."),
-    _("To do this, copy an IGC file into the XCSoarData/logs folder."),
-    _("Then you can select this file under Config → Config → Replay and start the flight simulation."));
-  UTF8ToWideConverter t97w(t97s.c_str());
-  PixelRect t97_rc{x, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
-  unsigned t97_height = canvas.DrawFormattedText(t97_rc, static_cast<const TCHAR *>(t97w), DT_LEFT);
+  StaticString<1024> t97;
+  t97 = _("The easiest way to get familiar with XCSoar is to load an "
+          "existing flight and use the replay feature to explore its "
+          "functions.");
+  t97 += _T(" ");
+  t97 += _("To do this, copy an IGC file into the XCSoarData/logs "
+          "folder.");
+  t97 += _T(" ");
+  t97 += _("Then you can select this file under Config → Config → "
+          "Replay and start the flight simulation.");
+  PixelRect t97_rc{x, y, int(canvas.GetWidth()) - margin,
+                   int(canvas.GetHeight())};
+  unsigned t97_height = canvas.DrawFormattedText(t97_rc, t97.c_str(), DT_LEFT);
   y += int(t97_height) + margin;
 
   canvas.Select(fontSmall);
-  const TCHAR *t98 = _("Maps, waypoints, etc. downloaded using the download feature can be updated in the file manager (Config → Config → File manager).");
-  PixelRect t98_rc{x, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
+  const TCHAR *t98 = _("Maps, waypoints, etc. downloaded using the "
+                       "download feature can be updated in the file "
+                       "manager (Config → Config → File manager).");
+  PixelRect t98_rc{x, y, int(canvas.GetWidth()) - margin,
+                   int(canvas.GetHeight())};
   unsigned t98_height = canvas.DrawFormattedText(t98_rc, t98, DT_LEFT);
   y += int(t98_height) + margin;
 
   canvas.Select(fontSmall);
-  const TCHAR *t99 = _("Files are stored in the operating system of the mobile device and can also be replaced and supplemented there, e.g., to add custom waypoints for a competition. On iOS, these files are located here: Files app → On my iPhone → XCSoar → XCSoarData. On Android, these files are located here: Android → media → org.xcsoar.");
-  PixelRect t99_rc{x, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
+  const TCHAR *t99 = _("Files are stored in the operating system of the "
+                       "mobile device and can also be replaced and "
+                       "supplemented there, e.g., to add custom waypoints "
+                       "for a competition. On iOS, these files are located "
+                       "here: Files app → On my iPhone → XCSoar → "
+                       "XCSoarData. On Android, these files are located "
+                       "here: Android → media → org.xcsoar.");
+  PixelRect t99_rc{x, y, int(canvas.GetWidth()) - margin,
+                   int(canvas.GetHeight())};
   canvas.DrawFormattedText(t99_rc, t99, DT_LEFT);
 }
 
@@ -338,7 +396,8 @@ ConfigurationWindow::HandleLink(LinkAction link) noexcept
   }
 
   case LinkAction::YOUTUBE_TUTORIAL:
-    OpenLink("https://youtube.com/playlist?list=PLb36zVafnfctzNG7yJoNXc2x8HnX5J9j7");
+    OpenLink("https://youtube.com/playlist?list="
+             "PLb36zVafnfctzNG7yJoNXc2x8HnX5J9j7");
     return true;
 
   case LinkAction::DEVICES:
@@ -361,7 +420,9 @@ unsigned
 ConfigurationWindow::DrawLink(Canvas &canvas, LinkAction link, PixelRect rc,
                               const TCHAR *text) noexcept
 {
-  return QuickGuideLinkWindow::DrawLink(canvas, static_cast<std::size_t>(link), rc, text);
+  return QuickGuideLinkWindow::DrawLink(canvas,
+                                        static_cast<std::size_t>(link),
+                                        rc, text);
 }
 
 bool

--- a/src/Dialogs/QuickGuide/ConfigurationWidget.hpp
+++ b/src/Dialogs/QuickGuide/ConfigurationWidget.hpp
@@ -6,6 +6,8 @@
 #include "QuickGuideLinkWindow.hpp"
 #include "Widget/WindowWidget.hpp"
 
+#include <cstdint>
+
 class Canvas;
 
 class ConfigurationWindow final : public QuickGuideLinkWindow {

--- a/src/Dialogs/QuickGuide/PostflightWidget.cpp
+++ b/src/Dialogs/QuickGuide/PostflightWidget.cpp
@@ -7,7 +7,7 @@
 #include "ui/canvas/Font.hpp"
 #include "Look/FontDescription.hpp"
 #include "Language/Language.hpp"
-#include "util/ConvertString.hpp"
+#include "util/StaticString.hxx"
 #include "Look/DialogLook.hpp"
 #include "UIGlobals.hpp"
 #include "Dialogs/Dialogs.h"
@@ -23,7 +23,6 @@
 #include "Profile/Profile.hpp"
 
 #include <winuser.h>
-#include <fmt/format.h>
 
 PixelSize PostflightWidget::GetMinimumSize() const noexcept {
   return { Layout::FastScale(200), Layout::FastScale(200) };
@@ -33,7 +32,10 @@ PixelSize PostflightWidget::GetMaximumSize() const noexcept {
   return { Layout::FastScale(300), Layout::FastScale(500) };
 }
 
-void PostflightWidget::Initialise(ContainerWindow &parent, const PixelRect &rc) noexcept {
+void
+PostflightWidget::Initialise(ContainerWindow &parent,
+                             const PixelRect &rc) noexcept
+{
   WindowStyle style;
   style.Hide();
   auto w = std::make_unique<PostflightWindow>();
@@ -64,70 +66,85 @@ PostflightWindow::OnPaint(Canvas &canvas) noexcept
   canvas.SetBackgroundTransparent();
   canvas.SetTextColor(COLOR_BLACK);
 
-  const TCHAR *t0 = _("After your flight, there are several steps to check and complete.");
-  PixelRect t0_rc{x, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
+  const TCHAR *t0 = _("After your flight, there are several steps to check "
+                      "and complete.");
+  PixelRect t0_rc{x, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
   unsigned t0_height = canvas.DrawFormattedText(t0_rc, t0, DT_LEFT);
   y += int(t0_height) + margin;
 
   // 1. Download Flight Log
-  canvas.DrawText({x, y}, "1.)");
-  std::string s1 = fmt::format("{} {}",
-    _("Download flight logs from your connected NMEA device, such as a FLARM unit or another supported logger."),
-    _("List available logs and save them in XCSoarData/logs, from where they can be manually uploaded to other devices or platforms such as WeGlide."));
-  UTF8ToWideConverter t1(s1.c_str());
-  PixelRect t1_rc{x_indent, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
-  unsigned t1_height = canvas.DrawFormattedText(t1_rc, static_cast<const TCHAR *>(t1), DT_LEFT);
+  canvas.DrawText({x, y}, _T("1.)"));
+  StaticString<1024> t1;
+  t1 = _("Download flight logs from your connected NMEA device, such "
+         "as a FLARM unit or another supported logger.");
+  t1 += _T(" ");
+  t1 += _("List available logs and save them in XCSoarData/logs, "
+          "from where they can be manually uploaded to other devices "
+          "or platforms such as WeGlide.");
+  PixelRect t1_rc{x_indent, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
+  unsigned t1_height = canvas.DrawFormattedText(t1_rc, t1.c_str(), DT_LEFT);
   y += int(t1_height) + margin / 2;
   canvas.Select(fontMono);
   const TCHAR *l1 = _("Config → Devices → Flight download");
-  PixelRect l1_rc{x_indent, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
+  PixelRect l1_rc{x_indent, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
   unsigned l1_height = DrawLink(canvas, LinkAction::FLIGHT_DOWNLOAD, l1_rc, l1);
   canvas.Select(fontDefault);
   y += int(l1_height) + margin;
 
   // 2. Flight Analysis
-  canvas.DrawText({x, y}, "2.)");
-  std::string s2 = fmt::format("{}",
-    _("Review statistical data from your flight such as your flight score, barograph, and glide polar analysis."));
-  UTF8ToWideConverter t2(s2.c_str());
-  PixelRect t2_rc{x_indent, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
-  unsigned t2_height = canvas.DrawFormattedText(t2_rc, static_cast<const TCHAR *>(t2), DT_LEFT);
+  canvas.DrawText({x, y}, _T("2.)"));
+  const TCHAR *t2 = _("Review statistical data from your flight such "
+                      "as your flight score, barograph, and glide "
+                      "polar analysis.");
+  PixelRect t2_rc{x_indent, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
+  unsigned t2_height = canvas.DrawFormattedText(t2_rc, t2, DT_LEFT);
   y += int(t2_height) + margin / 2;
   canvas.Select(fontMono);
   const TCHAR *l2 = _("Info → Analysis");
-  PixelRect l2_rc{x_indent, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
+  PixelRect l2_rc{x_indent, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
   unsigned l2_height = DrawLink(canvas, LinkAction::ANALYSIS, l2_rc, l2);
   canvas.Select(fontDefault);
   y += int(l2_height) + margin;
 
   // 3. Flight Status
-  canvas.DrawText({x, y}, "3.)");
-  std::string s3 = fmt::format("{}",
-    _("Check detailed statistics and timing information of your flight."));
-  UTF8ToWideConverter t3(s3.c_str());
-  PixelRect t3_rc{x_indent, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
-  unsigned t3_height = canvas.DrawFormattedText(t3_rc, static_cast<const TCHAR *>(t3), DT_LEFT);
+  canvas.DrawText({x, y}, _T("3.)"));
+  const TCHAR *t3 = _("Check detailed statistics and timing "
+                      "information of your flight.");
+  PixelRect t3_rc{x_indent, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
+  unsigned t3_height = canvas.DrawFormattedText(t3_rc, t3, DT_LEFT);
   y += int(t3_height) + margin / 2;
   canvas.Select(fontMono);
   const TCHAR *l3 = _("Info → Info → Status");
-  PixelRect l3_rc{x_indent, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
+  PixelRect l3_rc{x_indent, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
   unsigned l3_height = DrawLink(canvas, LinkAction::STATUS, l3_rc, l3);
   canvas.Select(fontDefault);
   y += int(l3_height) + margin;
 
   // 4. Upload Flight
-  canvas.DrawText({x, y}, "4.)");
-  std::string s4 = fmt::format("{} {} {}",
-    _("Flights can be uploaded directly from XCSoar to WeGlide."),
-    _("For this, configure your WeGlide User ID and date of birth in the system setup."),
-    _("You can find your User ID on weglide.org under 'My profile' by copying the numbers from the URL."));
-  UTF8ToWideConverter t4(s4.c_str());
-  PixelRect t4_rc{x_indent, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
-  unsigned t4_height = canvas.DrawFormattedText(t4_rc, static_cast<const TCHAR *>(t4), DT_LEFT);
+  canvas.DrawText({x, y}, _T("4.)"));
+  StaticString<1024> t4;
+  t4 = _("Flights can be uploaded directly from XCSoar to WeGlide.");
+  t4 += _T(" ");
+  t4 += _("For this, configure your WeGlide User ID and date of "
+          "birth in the system setup.");
+  t4 += _T(" ");
+  t4 += _("You can find your User ID on weglide.org under "
+          "'My profile' by copying the numbers from the URL.");
+  PixelRect t4_rc{x_indent, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
+  unsigned t4_height = canvas.DrawFormattedText(t4_rc, t4.c_str(), DT_LEFT);
   y += int(t4_height) + margin / 2;
   canvas.Select(fontMono);
   const TCHAR *l4 = _("Config → System → Setup → WeGlide");
-  PixelRect l4_rc{x_indent, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
+  PixelRect l4_rc{x_indent, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
   unsigned l4_height = DrawLink(canvas, LinkAction::WEGLIDE, l4_rc, l4);
   canvas.Select(fontDefault);
   y += int(l4_height) + margin;
@@ -168,7 +185,8 @@ PostflightWindow::HandleLink(LinkAction link) noexcept
 
   case LinkAction::WEGLIDE: {
     const DialogLook &look = UIGlobals::GetDialogLook();
-    WidgetDialog dialog(WidgetDialog::Full{}, UIGlobals::GetMainWindow(), look, _("WeGlide"));
+    WidgetDialog dialog(WidgetDialog::Full{}, UIGlobals::GetMainWindow(),
+                        look, _("WeGlide"));
     auto panel = CreateWeGlideConfigPanel();
     dialog.FinishPreliminary(std::move(panel));
     dialog.AddButton(_("Close"), mrOK);
@@ -187,10 +205,12 @@ PostflightWindow::HandleLink(LinkAction link) noexcept
 }
 
 unsigned
-PostflightWindow::DrawLink(Canvas &canvas, LinkAction link_action, PixelRect rc,
-                           const TCHAR *text) noexcept
+PostflightWindow::DrawLink(Canvas &canvas, LinkAction link_action,
+                           PixelRect rc, const TCHAR *text) noexcept
 {
-  return QuickGuideLinkWindow::DrawLink(canvas, static_cast<std::size_t>(link_action), rc, text);
+  return QuickGuideLinkWindow::DrawLink(canvas,
+                                        static_cast<std::size_t>(link_action),
+                                        rc, text);
 }
 
 bool

--- a/src/Dialogs/QuickGuide/PostflightWidget.hpp
+++ b/src/Dialogs/QuickGuide/PostflightWidget.hpp
@@ -6,6 +6,8 @@
 #include "QuickGuideLinkWindow.hpp"
 #include "Widget/WindowWidget.hpp"
 
+#include <cstdint>
+
 class PostflightWindow final : public QuickGuideLinkWindow {
   enum class LinkAction : std::uint8_t {
     FLIGHT_DOWNLOAD,

--- a/src/Dialogs/QuickGuide/PreflightWidget.cpp
+++ b/src/Dialogs/QuickGuide/PreflightWidget.cpp
@@ -7,7 +7,7 @@
 #include "ui/canvas/Font.hpp"
 #include "Look/FontDescription.hpp"
 #include "Language/Language.hpp"
-#include "util/ConvertString.hpp"
+#include "util/StaticString.hxx"
 #include "Look/DialogLook.hpp"
 #include "UIGlobals.hpp"
 #include "Dialogs/Dialogs.h"
@@ -15,7 +15,6 @@
 #include "Dialogs/Task/TaskDialogs.hpp"
 
 #include <winuser.h>
-#include <fmt/format.h>
 
 PixelSize PreflightWidget::GetMinimumSize() const noexcept {
   return { Layout::FastScale(200), Layout::FastScale(200) };
@@ -25,7 +24,10 @@ PixelSize PreflightWidget::GetMaximumSize() const noexcept {
   return { Layout::FastScale(300), Layout::FastScale(500) };
 }
 
-void PreflightWidget::Initialise(ContainerWindow &parent, const PixelRect &rc) noexcept {
+void
+PreflightWidget::Initialise(ContainerWindow &parent,
+                            const PixelRect &rc) noexcept
+{
   WindowStyle style;
   style.Hide();
   auto w = std::make_unique<PreflightWindow>();
@@ -56,84 +58,94 @@ PreflightWindow::OnPaint(Canvas &canvas) noexcept
   canvas.SetBackgroundTransparent();
   canvas.SetTextColor(COLOR_BLACK);
 
-  const TCHAR *t0 = _("There are several things that should be set and checked before each flight.");
-  PixelRect t0_rc{x, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
+  const TCHAR *t0 = _("There are several things that should be set and "
+                      "checked before each flight.");
+  PixelRect t0_rc{x, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
   unsigned t0_height = canvas.DrawFormattedText(t0_rc, t0, DT_LEFT);
   y += int(t0_height) + margin;
 
   // 1. Checklist
-  canvas.DrawText({x, y}, "1.)");
-  std::string s1 = fmt::format("{} {}",
-    _("It is possible to store a checklist."),
-    _("To do this, an xcsoar-checklist.txt file must be added to the XCSoarData folder."));
-  UTF8ToWideConverter t1(s1.c_str());
-  PixelRect t1_rc{x_indent, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
-  unsigned t1_height = canvas.DrawFormattedText(t1_rc, static_cast<const TCHAR *>(t1), DT_LEFT);
+  canvas.DrawText({x, y}, _T("1.)"));
+  StaticString<512> t1;
+  t1 = _("It is possible to store a checklist.");
+  t1 += _T(" ");
+  t1 += _("To do this, an xcsoar-checklist.txt file must be added "
+          "to the XCSoarData folder.");
+  PixelRect t1_rc{x_indent, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
+  unsigned t1_height = canvas.DrawFormattedText(t1_rc, t1.c_str(), DT_LEFT);
   y += int(t1_height) + margin / 2;
   canvas.Select(fontMono);
   const TCHAR *l1 = _("Info → Checklist");
-  PixelRect l1_rc{x_indent, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
+  PixelRect l1_rc{x_indent, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
   unsigned l1_height = DrawLink(canvas, LinkAction::CHECKLIST, l1_rc, l1);
   canvas.Select(fontDefault);
   y += int(l1_height) + margin;
 
 
   // 2. Aircraft / Polar
-  canvas.DrawText({x, y}, "2.)");
-  std::string s2 = fmt::format("{}",
-    _("Select and activate the correct aircraft and polar configuration, so that weight and performance are accurate."));
-  UTF8ToWideConverter t2(s2.c_str());
-  PixelRect t2_rc{x_indent, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
-  unsigned t2_height = canvas.DrawFormattedText(t2_rc, static_cast<const TCHAR *>(t2), DT_LEFT);
+  canvas.DrawText({x, y}, _T("2.)"));
+  const TCHAR *t2 = _("Select and activate the correct aircraft and polar "
+                      "configuration, so that weight and performance are "
+                      "accurate.");
+  PixelRect t2_rc{x_indent, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
+  unsigned t2_height = canvas.DrawFormattedText(t2_rc, t2, DT_LEFT);
   y += int(t2_height) + margin / 2;
   canvas.Select(fontMono);
   const TCHAR *l2 = _("Config → Plane");
-  PixelRect l2_rc{x_indent, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
+  PixelRect l2_rc{x_indent, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
   unsigned l2_height = DrawLink(canvas, LinkAction::PLANE, l2_rc, l2);
   canvas.Select(fontDefault);
   y += int(l2_height) + margin;
 
   // 3. Flight
-  canvas.DrawText({x, y}, "3.)");
-  std::string s3 = fmt::format("{}",
-    _("Set flight parameters such as wing loading, bugs, QNH and maximum temperature."));
-  UTF8ToWideConverter t3(s3.c_str());
-  PixelRect t3_rc{x_indent, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
-  unsigned t3_height = canvas.DrawFormattedText(t3_rc, static_cast<const TCHAR *>(t3), DT_LEFT);
+  canvas.DrawText({x, y}, _T("3.)"));
+  const TCHAR *t3 = _("Set flight parameters such as wing loading, bugs, "
+                      "QNH and maximum temperature.");
+  PixelRect t3_rc{x_indent, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
+  unsigned t3_height = canvas.DrawFormattedText(t3_rc, t3, DT_LEFT);
   y += int(t3_height) + margin / 2;
   canvas.Select(fontMono);
   const TCHAR *l3 = _("Info → Flight");
-  PixelRect l3_rc{x_indent, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
+  PixelRect l3_rc{x_indent, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
   unsigned l3_height = DrawLink(canvas, LinkAction::FLIGHT, l3_rc, l3);
   canvas.Select(fontDefault);
   y += int(l3_height) + margin;
 
   // 4. Wind
-  canvas.DrawText({x, y}, "4.)");
-  std::string s4 = fmt::format("{}",
-    _("Configure wind data manually or enable auto wind to set speed and direction."));
-  UTF8ToWideConverter t4(s4.c_str());
-  PixelRect t4_rc{x_indent, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
-  unsigned t4_height = canvas.DrawFormattedText(t4_rc, static_cast<const TCHAR *>(t4), DT_LEFT);
+  canvas.DrawText({x, y}, _T("4.)"));
+  const TCHAR *t4 = _("Configure wind data manually or enable auto wind to "
+                      "set speed and direction.");
+  PixelRect t4_rc{x_indent, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
+  unsigned t4_height = canvas.DrawFormattedText(t4_rc, t4, DT_LEFT);
   y += int(t4_height) + margin / 2;
   canvas.Select(fontMono);
   const TCHAR *l4 = _("Info → Wind");
-  PixelRect l4_rc{x_indent, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
+  PixelRect l4_rc{x_indent, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
   unsigned l4_height = DrawLink(canvas, LinkAction::WIND, l4_rc, l4);
   canvas.Select(fontDefault);
   y += int(l4_height) + margin;
 
   // 5. Task
-  canvas.DrawText({x, y}, "5.)");
-  std::string s5 = fmt::format("{}",
-    _("Create a task so XCSoar can guide navigation and provide return support."));
-  UTF8ToWideConverter t5(s5.c_str());
-  PixelRect t5_rc{x_indent, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
-  unsigned t5_height = canvas.DrawFormattedText(t5_rc, static_cast<const TCHAR *>(t5), DT_LEFT);
+  canvas.DrawText({x, y}, _T("5.)"));
+  const TCHAR *t5 = _("Create a task so XCSoar can guide navigation and "
+                      "provide return support.");
+  PixelRect t5_rc{x_indent, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
+  unsigned t5_height = canvas.DrawFormattedText(t5_rc, t5, DT_LEFT);
   y += int(t5_height) + margin / 2;
   canvas.Select(fontMono);
   const TCHAR *l5 = _("Nav → Task Manager");
-  PixelRect l5_rc{x_indent, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
+  PixelRect l5_rc{x_indent, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
   unsigned l5_height = DrawLink(canvas, LinkAction::TASK_MANAGER, l5_rc, l5);
   canvas.Select(fontDefault);
   y += int(l5_height) + margin;
@@ -176,7 +188,9 @@ unsigned
 PreflightWindow::DrawLink(Canvas &canvas, LinkAction link_action, PixelRect rc,
                           const TCHAR *text) noexcept
 {
-  return QuickGuideLinkWindow::DrawLink(canvas, static_cast<std::size_t>(link_action), rc, text);
+  return QuickGuideLinkWindow::DrawLink(canvas,
+                                        static_cast<std::size_t>(link_action),
+                                        rc, text);
 }
 
 bool

--- a/src/Dialogs/QuickGuide/PreflightWidget.hpp
+++ b/src/Dialogs/QuickGuide/PreflightWidget.hpp
@@ -6,6 +6,8 @@
 #include "QuickGuideLinkWindow.hpp"
 #include "Widget/WindowWidget.hpp"
 
+#include <cstdint>
+
 class Canvas;
 
 class PreflightWindow final : public QuickGuideLinkWindow {

--- a/src/Dialogs/QuickGuide/WelcomeWidget.cpp
+++ b/src/Dialogs/QuickGuide/WelcomeWidget.cpp
@@ -8,13 +8,12 @@
 #include "ui/canvas/Bitmap.hpp"
 #include "Resources.hpp"
 #include "Language/Language.hpp"
-#include "util/ConvertString.hpp"
 #include "util/OpenLink.hpp"
+#include "util/StaticString.hxx"
 #include "Look/DialogLook.hpp"
 #include "UIGlobals.hpp"
 
 #include <winuser.h>
-#include <fmt/format.h>
 
 PixelSize WelcomeWidget::GetMinimumSize() const noexcept {
   return { Layout::FastScale(200), Layout::FastScale(200) };
@@ -25,7 +24,8 @@ PixelSize WelcomeWidget::GetMaximumSize() const noexcept {
 }
 
 void
-WelcomeWidget::Initialise(ContainerWindow &parent, const PixelRect &rc) noexcept
+WelcomeWidget::Initialise(ContainerWindow &parent,
+                          const PixelRect &rc) noexcept
 {
   WindowStyle style;
   style.Hide();
@@ -69,50 +69,65 @@ WelcomeWindow::OnPaint(Canvas &canvas) noexcept
 
   canvas.Select(fontTitle);
   const TCHAR *t0 = _("Welcome to XCSoar");
-  PixelRect t0_rc{x, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
+  PixelRect t0_rc{x, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
   unsigned t0_height = canvas.DrawFormattedText(t0_rc, t0, DT_LEFT);
   y += int(t0_height) + margin;
   canvas.Select(fontDefault);
 
-  std::string s1 = fmt::format("{} {}",
-    _("To get the most out of XCSoar and to learn about its many functions in detail, "
-      "it is highly recommended to read the Quick Guide or the complete documentation."),
-    _("The manuals explain step by step how to use XCSoar efficiently "
-      "and cover both basic and advanced features."));
-  UTF8ToWideConverter t1(s1.c_str());
-  PixelRect t1_rc{x, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
-  unsigned t1_height = canvas.DrawFormattedText(t1_rc, static_cast<const TCHAR *>(t1), DT_LEFT);
+  StaticString<1024> t1;
+  t1 = _("To get the most out of XCSoar and to learn about its many "
+         "functions in detail, it is highly recommended to read the "
+         "Quick Guide or the complete documentation.");
+  t1 += _T(" ");
+  t1 += _("The manuals explain step by step how to use XCSoar "
+          "efficiently and cover both basic and advanced features.");
+  PixelRect t1_rc{x, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
+  unsigned t1_height = canvas.DrawFormattedText(t1_rc, t1.c_str(), DT_LEFT);
   y += int(t1_height) + margin;
 
-  std::string s2 = fmt::format("{} {}",
-    _("Documentation is available in several languages, including English, German, French, and Portuguese."),
-    _("You can always access the latest versions online:"));
-  UTF8ToWideConverter t2(s2.c_str());
-  PixelRect t2_rc{x, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
-  unsigned t2_height = canvas.DrawFormattedText(t2_rc, static_cast<const TCHAR *>(t2), DT_LEFT);
+  StaticString<512> t2;
+  t2 = _("Documentation is available in several languages, including "
+         "English, German, French, and Portuguese.");
+  t2 += _T(" ");
+  t2 += _("You can always access the latest versions online:");
+  PixelRect t2_rc{x, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
+  unsigned t2_height = canvas.DrawFormattedText(t2_rc, t2.c_str(), DT_LEFT);
   y += int(t2_height) + margin;
 
   canvas.SetTextColor(COLOR_BLUE);
   const TCHAR *t3 = _("https://xcsoar.org/discover/manual.html");
-  PixelRect t3_rc{x, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
-  unsigned t3_height = canvas.DrawFormattedText(t3_rc, t3, DT_LEFT | DT_UNDERLINE);
-  xcsoar_link_rect = {x, y, int(canvas.GetWidth()) - margin, y + int(t3_height)};
+  PixelRect t3_rc{x, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
+  unsigned t3_height =
+    canvas.DrawFormattedText(t3_rc, t3, DT_LEFT | DT_UNDERLINE);
+  xcsoar_link_rect = {x, y, int(canvas.GetWidth()) - margin,
+                      y + int(t3_height)};
   canvas.SetTextColor(COLOR_BLACK);
   y += int(t3_height) + margin;
 
-  std::string s4 = fmt::format("{} {}",
-    _("The XCSoar documentation is actively maintained, but some topics may still be missing or outdated."),
-    _("If you find mistakes or have ideas for improvement, please contribute — XCSoar is open source and thrives on community input:"));
-  UTF8ToWideConverter t4(s4.c_str());
-  PixelRect t4_rc{x, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
-  unsigned t4_height = canvas.DrawFormattedText(t4_rc, static_cast<const TCHAR *>(t4), DT_LEFT);
+  StaticString<1024> t4;
+  t4 = _("The XCSoar documentation is actively maintained, but some "
+         "topics may still be missing or outdated.");
+  t4 += _T(" ");
+  t4 += _("If you find mistakes or have ideas for improvement, "
+          "please contribute — XCSoar is open source and thrives on "
+          "community input:");
+  PixelRect t4_rc{x, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
+  unsigned t4_height = canvas.DrawFormattedText(t4_rc, t4.c_str(), DT_LEFT);
   y += int(t4_height) + margin;
 
   canvas.SetTextColor(COLOR_BLUE);
   const TCHAR *t5 = _("https://github.com/XCSoar/XCSoar");
-  PixelRect t5_rc{x, y, int(canvas.GetWidth()) - margin, int(canvas.GetHeight())};
-  unsigned t5_height = canvas.DrawFormattedText(t5_rc, t5, DT_LEFT | DT_UNDERLINE);
-  github_link_rect = {x, y, int(canvas.GetWidth()) - margin, y + int(t5_height)};
+  PixelRect t5_rc{x, y, int(canvas.GetWidth()) - margin,
+                  int(canvas.GetHeight())};
+  unsigned t5_height =
+    canvas.DrawFormattedText(t5_rc, t5, DT_LEFT | DT_UNDERLINE);
+  github_link_rect = {x, y, int(canvas.GetWidth()) - margin,
+                      y + int(t5_height)};
   canvas.SetTextColor(COLOR_BLACK);
   y += int(t5_height) + margin;
 }

--- a/src/ui/canvas/Canvas.hpp
+++ b/src/ui/canvas/Canvas.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "TextFormat.hpp"
+
 #ifdef ENABLE_OPENGL
 #include "opengl/Canvas.hpp"
 #elif defined(USE_MEMORY_CANVAS)

--- a/src/ui/canvas/TextFormat.hpp
+++ b/src/ui/canvas/TextFormat.hpp
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#ifndef DT_LEFT
+#define DT_LEFT 0x2
+#endif
+#ifndef DT_CENTER
+#define DT_CENTER 0x20
+#endif
+#ifndef DT_VCENTER
+#define DT_VCENTER 0x80
+#endif
+#ifndef DT_RIGHT
+#define DT_RIGHT 0x100
+#endif
+#ifndef DT_CALCRECT
+#define DT_CALCRECT 0x400
+#endif
+#ifndef DT_UNDERLINE
+#define DT_UNDERLINE 0x800
+#endif

--- a/src/unix/winuser.h
+++ b/src/unix/winuser.h
@@ -3,11 +3,4 @@
 
 #pragma once
 
-enum {
-  DT_LEFT = 0x2,
-  DT_CENTER = 0x20,
-  DT_VCENTER = 0x80,
-  DT_RIGHT = 0x100,
-  DT_CALCRECT = 0x400,
-  DT_UNDERLINE = 0x800,
-};
+#include "ui/canvas/TextFormat.hpp"


### PR DESCRIPTION
Fixes the `TCHAR` compile error.
Generates `.bmp` for `WIN64`.
Consolidate `DT_*` text-formatting flags into a shared `TextFormat.hpp` so all platforms use one definition and `WIN64` builds no longer fail on missing `DT_UNDERLINE`.
Sticking to the XCSoar 79 characters-per-line limit wherever reasonable. 

You can test this on macOS via cross-compiling, just `make TARGET=WIN64 -j8` should work.

CI run still running https://github.com/yorickreum/XCSoar/actions/runs/20642114218/job/59275226127, please check before you merge.

Thanks for all your efforts!